### PR TITLE
fix: esm only support

### DIFF
--- a/config/bundle/rollup-core.js
+++ b/config/bundle/rollup-core.js
@@ -3,7 +3,7 @@
 const { builtinModules } = require('node:module');
 const { nodeResolve }    = require('@rollup/plugin-node-resolve');
 const commonjs           = require('@rollup/plugin-commonjs');
-const alias              = require('@rollup/plugin-alias');
+const { alias }          = require('./rollup-plugin-bridge.mjs');
 const replacer           = require('@rollup/plugin-replace');
 const css                = require('rollup-plugin-import-css');
 const sourcemapDetect    = require('@cdp/tasks/rollup-plugin/source-map-detect');

--- a/config/bundle/rollup-plugin-bridge.mjs
+++ b/config/bundle/rollup-plugin-bridge.mjs
@@ -1,0 +1,2 @@
+import alias from '@rollup/plugin-alias';
+export { alias };

--- a/config/bundle/rollup-test.js
+++ b/config/bundle/rollup-test.js
@@ -3,7 +3,7 @@
 const multiEntry        = require('@rollup/plugin-multi-entry');
 const { nodeResolve }   = require('@rollup/plugin-node-resolve');
 const commonjs          = require('@rollup/plugin-commonjs');
-const alias             = require('@rollup/plugin-alias');
+const { alias }         = require('./rollup-plugin-bridge.mjs');
 const replacer          = require('@rollup/plugin-replace');
 const sourcemapDetect   = require('@cdp/tasks/rollup-plugin/source-map-detect');
 const sourcemapRoot     = require('@cdp/tasks/rollup-plugin/source-map-root');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@cdp/tasks": "file:packages/tool/tasks",
         "@eslint/js": "9.38.0",
-        "@rollup/plugin-alias": "5.1.1",
+        "@rollup/plugin-alias": "6.0.0",
         "@rollup/plugin-commonjs": "29.0.0",
         "@rollup/plugin-multi-entry": "7.1.0",
         "@rollup/plugin-node-resolve": "16.0.3",
@@ -1141,16 +1141,16 @@
       }
     },
     "node_modules/@rollup/plugin-alias": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
-      "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
+      "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+        "rollup": ">=4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@cdp/tasks": "file:packages/tool/tasks",
     "@eslint/js": "9.38.0",
-    "@rollup/plugin-alias": "5.1.1",
+    "@rollup/plugin-alias": "6.0.0",
     "@rollup/plugin-commonjs": "29.0.0",
     "@rollup/plugin-multi-entry": "7.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",


### PR DESCRIPTION
rollup-plugin ESM only module のサポート

- @rollup/plugin-alias: v6.0.0
- rollup-plugin-bridge.mjs
